### PR TITLE
Add linear velocity estimator.

### DIFF
--- a/legged_gym/envs/base/legged_robot_no_lin_vel.py
+++ b/legged_gym/envs/base/legged_robot_no_lin_vel.py
@@ -20,32 +20,7 @@ class LeggedRobotNoLinVel(LeggedRobot):
         # add perceptive inputs if not blind
         # add noise if needed
         if self.add_noise:
-            self.obs_buf += (2 * torch.rand_like(self.obs_buf) - 1) * self.noise_scale_vec
+            self.obs_buf += (2 * torch.rand_like(self.obs_buf) - 1) * self.noise_scale_vec[3:]
 
         # only uncomment when play_with_plots.py. ELSE it will mess up training because of critic
         # self.privileged_obs_buf = torch.cat((self.base_lin_vel * self.obs_scales.lin_vel,), dim=-1)
-
-    def _get_noise_scale_vec(self, cfg):
-        """ Sets a vector used to scale the noise added to the observations.
-            [NOTE]: Must be adapted when changing the observations structure
-
-        Args:
-            cfg (Dict): Environment config file
-
-        Returns:
-            [torch.Tensor]: Vector of scales used to multiply a uniform distribution in [-1, 1]
-        """
-        noise_vec = torch.zeros_like(self.obs_buf[0])
-        self.add_noise = self.cfg.noise.add_noise
-        noise_scales = self.cfg.noise.noise_scales
-        noise_level = self.cfg.noise.noise_level
-        noise_vec[:3] = noise_scales.ang_vel * noise_level * self.obs_scales.ang_vel
-        noise_vec[3:6] = noise_scales.gravity * noise_level
-        noise_vec[6:9] = 0. # commands
-        noise_vec[9:9+self.num_actions] = noise_scales.dof_pos * noise_level * self.obs_scales.dof_pos
-        noise_vec[9+self.num_actions:9+2*self.num_actions] = noise_scales.dof_vel * noise_level * self.obs_scales.dof_vel
-        noise_vec[9+2*self.num_actions:9+3*self.num_actions] = 0. # previous actions
-        noise_vec[9+3*self.num_actions:9+4*self.num_actions] = noise_scales.dof_pos * noise_level * self.obs_scales.dof_pos
-        noise_vec[9+4*self.num_actions:9+5*self.num_actions] = noise_scales.dof_vel * noise_level * self.obs_scales.dof_vel
-
-        return noise_vec

--- a/legged_gym/envs/go2/go2_config.py
+++ b/legged_gym/envs/go2/go2_config.py
@@ -25,6 +25,7 @@ class GO2RoughCfg( LeggedRobotCfg ):
     class env(LeggedRobotCfg.env):
         history_length = 3
         num_observations = 48 + LeggedRobotCfg.env.num_actions * (history_length+1)
+        lin_vel_estimator_path = None # Will use estimator at path as input observation. If None, will use privileged linear velocity.
 
     class domain_rand(LeggedRobotCfg.domain_rand):
         randomize_friction = True

--- a/legged_gym/scripts/train_state_estimator.py
+++ b/legged_gym/scripts/train_state_estimator.py
@@ -1,24 +1,36 @@
+"""
+Update SAVE_PATH and POLICY_PATH.
+
+Run this script after training a policy to walk (and that takes in its linear velocity as input).
+
+Will output an estimator policy which takes in observations (not including linear velocity or the command) and outputs estimated base linear velocity (before simulation scaling).
+"""
+
 import isaacgym
 from legged_gym.envs import * # required to prevent circular imports
 from legged_gym.utils import get_args, task_registry
 from legged_gym.envs.go2.go2_config import GO2RoughCfg, GO2RoughCfgPPO
+from rsl_rl.modules import ActorCritic
 
 import torch
 import torch.nn.functional as F
 
 from legged_gym.utils.actor import Actor
+
+SAVE_PATH = ...
+
+POLICY_PATH = ...
+
 class Trainer:
     def __init__(
             self,
-            num_obs,
-            num_actions,
             learning_rate=0.001,
             batch_size=1024,
             mini_batch_size=512,
             weight_decay=0.0005,
             num_epochs=500,
-            num_processes=4096,
             device="cuda:0",
+            args=None,
         ):
         self.learning_rate = learning_rate
         self.batch_size = batch_size
@@ -26,9 +38,18 @@ class Trainer:
         self.weight_decay = weight_decay
         self.num_epochs = num_epochs
 
+        self.env, env_cfg = self._load_env(args)
+        self.policy_num_obs = env_cfg.env.num_observations
+
+        # remove linear velocity and command
+        self.estimator_num_obs = self.policy_num_obs - 6
+
+        self.estimator_num_actions = 3
+        self.policy_num_actions = env_cfg.env.num_actions
+
         self.estimator = Actor(
-            num_actor_obs=num_obs,
-            num_actions=num_actions,
+            num_actor_obs=self.estimator_num_obs,
+            num_actions=self.estimator_num_actions,
             actor_hidden_dims=[256, 128],
             activation="elu",
             init_noise_std=1.0,
@@ -37,40 +58,58 @@ class Trainer:
 
         self.estimator.to(device)
 
-        self.num_steps = self.batch_size // num_processes + 1
+        self.num_steps = self.batch_size // env_cfg.env.num_envs + 1
 
-        self.self.bservations = torch.zeros(
-            self.num_steps + 1, num_processes, (num_obs,), device="cpu"
+        self.buffer_policy_observations = torch.zeros(
+            self.num_steps + 1, env_cfg.env.num_envs, (self.policy_num_obs,), device="cpu"
         )
-        self.buffer_actions = torch.zeros(self.num_steps, num_processes, num_actions, device="cpu")
-        self.num_actions = num_actions
-        self.num_obs = num_obs
+        self.buffer_estimator_actions = torch.zeros(self.num_steps, env_cfg.env.num_envs, self.estimator_num_actions, device="cpu")
 
     def _load_env(self, args):
         cfg = GO2RoughCfg()
 
         env, env_cfg = task_registry.make_env(name=args.task, args=args, env_cfg=cfg)
-        return env
+        return env, env_cfg
+    
+    def load_model(self, model_path, device="cuda:0"):
+        model = ActorCritic(
+                num_actor_obs=self.policy_num_obs,
+                num_critic_obs=self.policy_num_obs,
+                num_actions=self.policy_num_actions,
+                actor_hidden_dims=[512, 256, 128],
+                critic_hidden_dims=[512, 256, 128],
+                activation='elu',
+                init_noise_std=1.0
+            )
+        
+        model.to(device)
+
+        if model_path is not None:
+            model.load_state_dict(torch.load(model_path, map_location=torch.device(device))['model_state_dict'])
+
+        model.eval()
+        return model
 
     def train(self, args):
-        env = self._load_env(args)
+        policy = self.load(POLICY_PATH)
 
-        obs = env.reset()[0]
-        self.buffer_observations[-1].copy_(obs[:,self.num_actions:].to("cpu"))
+        obs = self.env.reset()[0]
+        self.buffer_policy_observations[-1].copy_(obs.to("cpu"))
 
         optimizer = torch.optim.Adam(self.estimator.parameters(), lr=self.learning_rate, weight_decay=self.weight_decay)
         for epoch in range(self.num_epochs):
             with torch.no_grad():
-                self.buffer_observations[0].copy_(self.buffer_observations[-1])
+                self.buffer_policy_observations[0].copy_(self.buffer_policy_observations[-1])
                 for step in range(self.num_steps):
-                    action = self.estimator.act(
-                        self.buffer_observations[step].to(args.rl_device)
+                    action = policy.act(
+                        self.buffer_policy_observations[step].to(args.rl_device)
                     )
 
-                    obs, _, _, _, _ = env.step(action)
+                    obs, privileged_obs, _, _, _ = self.env.step(action)
 
-                    self.buffer_observations[step + 1].copy_(obs[:,3:].to("cpu"))
-                    self.buffer_actions[step].copy_(action.to("cpu"))
+                    self.buffer_policy_observations[step + 1].copy_(obs.to("cpu"))
+                    # no noise?
+                    self.buffer_estimator_actions[step].copy_(privileged_obs[:,0:3].to("cpu"))
 
         num_mini_batch = self.batch_size // self.mini_batch_size
         shuffled_indices = torch.randperm(
@@ -78,8 +117,8 @@ class Trainer:
         )
         shuffled_indices_batch = shuffled_indices.view(num_mini_batch, -1)
 
-        observations_shaped = self.buffer_observations.view(-1, self.num_obs)
-        actions_shaped = self.buffer_actions.view(-1, self.num_actions)
+        observations_shaped = self.buffer_policy_observations.view(-1, self.policy_num_obs)
+        actions_shaped = self.buffer_estimator_actions.view(-1, self.estimator_num_actions)
 
         ep_action_loss = torch.tensor(0.0, device=args.rl_device).float()
 
@@ -87,7 +126,10 @@ class Trainer:
             observations_batch = observations_shaped[indices]
             actions_batch = actions_shaped[indices]
 
-            pred_actions = self.estimator.act_inference(observations_batch.to("cuda:0"))
+            # remove linear velocity and command
+            pred_actions = self.estimator.act_inference(
+                torch.cat((observations_batch[:, 3:9], observations_batch[:, 12:]), dim=1).to("cuda:0")
+            )
 
             # Forward pass
             optimizer.zero_grad()
@@ -102,8 +144,22 @@ class Trainer:
 
         if epoch % 50 == 0:
             print(f"Epoch {epoch}/{self.num_epochs}, Loss: {ep_action_loss.item()}")
+            torch.save({
+            'model_state_dict': self.estimator.state_dict(),
+            'optimizer_state_dict': optimizer.state_dict(),
+            'iter': epoch,
+            "infos": None,
+            }, f"{SAVE_PATH}/model.pt")
 
 if __name__ == '__main__':
     args = get_args()
-    trainer = Trainer(num_obs=..., num_actions=...)
+    trainer = Trainer(
+        learning_rate=0.001, # could try 3e-4 instead
+        batch_size=1024 * 10, # unsure about this parameter
+        mini_batch_size=512,
+        weight_decay=0.0005,
+        num_epochs=500,
+        device="cuda:0",
+        args=args,
+    )
     trainer.train(args)

--- a/legged_gym/scripts/train_state_estimator.py
+++ b/legged_gym/scripts/train_state_estimator.py
@@ -1,0 +1,109 @@
+import isaacgym
+from legged_gym.envs import * # required to prevent circular imports
+from legged_gym.utils import get_args, task_registry
+from legged_gym.envs.go2.go2_config import GO2RoughCfg, GO2RoughCfgPPO
+
+import torch
+import torch.nn.functional as F
+
+from legged_gym.utils.actor import Actor
+class Trainer:
+    def __init__(
+            self,
+            num_obs,
+            num_actions,
+            learning_rate=0.001,
+            batch_size=1024,
+            mini_batch_size=512,
+            weight_decay=0.0005,
+            num_epochs=500,
+            num_processes=4096,
+            device="cuda:0",
+        ):
+        self.learning_rate = learning_rate
+        self.batch_size = batch_size
+        self.mini_batch_size = mini_batch_size
+        self.weight_decay = weight_decay
+        self.num_epochs = num_epochs
+
+        self.estimator = Actor(
+            num_actor_obs=num_obs,
+            num_actions=num_actions,
+            actor_hidden_dims=[256, 128],
+            activation="elu",
+            init_noise_std=1.0,
+            noise_std_type="scalar"
+        )
+
+        self.estimator.to(device)
+
+        self.num_steps = self.batch_size // num_processes + 1
+
+        self.self.bservations = torch.zeros(
+            self.num_steps + 1, num_processes, (num_obs,), device="cpu"
+        )
+        self.buffer_actions = torch.zeros(self.num_steps, num_processes, num_actions, device="cpu")
+        self.num_actions = num_actions
+        self.num_obs = num_obs
+
+    def _load_env(self, args):
+        cfg = GO2RoughCfg()
+
+        env, env_cfg = task_registry.make_env(name=args.task, args=args, env_cfg=cfg)
+        return env
+
+    def train(self, args):
+        env = self._load_env(args)
+
+        obs = env.reset()[0]
+        self.buffer_observations[-1].copy_(obs[:,self.num_actions:].to("cpu"))
+
+        optimizer = torch.optim.Adam(self.estimator.parameters(), lr=self.learning_rate, weight_decay=self.weight_decay)
+        for epoch in range(self.num_epochs):
+            with torch.no_grad():
+                self.buffer_observations[0].copy_(self.buffer_observations[-1])
+                for step in range(self.num_steps):
+                    action = self.estimator.act(
+                        self.buffer_observations[step].to(args.rl_device)
+                    )
+
+                    obs, _, _, _, _ = env.step(action)
+
+                    self.buffer_observations[step + 1].copy_(obs[:,3:].to("cpu"))
+                    self.buffer_actions[step].copy_(action.to("cpu"))
+
+        num_mini_batch = self.batch_size // self.mini_batch_size
+        shuffled_indices = torch.randperm(
+            num_mini_batch * self.mini_batch_size, generator=None, device="cpu"
+        )
+        shuffled_indices_batch = shuffled_indices.view(num_mini_batch, -1)
+
+        observations_shaped = self.buffer_observations.view(-1, self.num_obs)
+        actions_shaped = self.buffer_actions.view(-1, self.num_actions)
+
+        ep_action_loss = torch.tensor(0.0, device=args.rl_device).float()
+
+        for indices in shuffled_indices_batch:
+            observations_batch = observations_shaped[indices]
+            actions_batch = actions_shaped[indices]
+
+            pred_actions = self.estimator.act_inference(observations_batch.to("cuda:0"))
+
+            # Forward pass
+            optimizer.zero_grad()
+            loss = F.mse_loss(pred_actions, actions_batch.to("cuda:0"))
+            loss.backward()
+            optimizer.step()
+
+            ep_action_loss.add_(loss.detach())
+
+        L = shuffled_indices_batch.shape[0]
+        ep_action_loss.div_(L)
+
+        if epoch % 50 == 0:
+            print(f"Epoch {epoch}/{self.num_epochs}, Loss: {ep_action_loss.item()}")
+
+if __name__ == '__main__':
+    args = get_args()
+    trainer = Trainer(num_obs=..., num_actions=...)
+    trainer.train(args)

--- a/legged_gym/utils/actor.py
+++ b/legged_gym/utils/actor.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2021-2025, ETH Zurich and NVIDIA CORPORATION
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+
+from rsl_rl.utils import resolve_nn_activation
+
+
+class Actor(nn.Module):
+    is_recurrent = False
+
+    def __init__(
+        self,
+        num_actor_obs,
+        num_actions,
+        actor_hidden_dims=[256, 128],
+        activation="elu",
+        init_noise_std=1.0,
+        noise_std_type: str = "scalar",
+        **kwargs,
+    ):
+        if kwargs:
+            print(
+                "Actor.__init__ got unexpected arguments, which will be ignored: "
+                + str([key for key in kwargs.keys()])
+            )
+        super().__init__()
+        activation = resolve_nn_activation(activation)
+
+        mlp_input_dim_a = num_actor_obs
+        # Policy
+        actor_layers = []
+        actor_layers.append(nn.Linear(mlp_input_dim_a, actor_hidden_dims[0]))
+        actor_layers.append(activation)
+        for layer_index in range(len(actor_hidden_dims)):
+            if layer_index == len(actor_hidden_dims) - 1:
+                actor_layers.append(nn.Linear(actor_hidden_dims[layer_index], num_actions))
+            else:
+                actor_layers.append(nn.Linear(actor_hidden_dims[layer_index], actor_hidden_dims[layer_index + 1]))
+                actor_layers.append(activation)
+        self.actor = nn.Sequential(*actor_layers)
+
+        print(f"Actor MLP: {self.actor}")
+
+        # Action noise
+        self.noise_std_type = noise_std_type
+        if self.noise_std_type == "scalar":
+            self.std = nn.Parameter(init_noise_std * torch.ones(num_actions))
+        elif self.noise_std_type == "log":
+            self.log_std = nn.Parameter(torch.log(init_noise_std * torch.ones(num_actions)))
+        else:
+            raise ValueError(f"Unknown standard deviation type: {self.noise_std_type}. Should be 'scalar' or 'log'")
+
+        # Action distribution (populated in update_distribution)
+        self.distribution = None
+        # disable args validation for speedup
+        Normal.set_default_validate_args(False)
+
+    @staticmethod
+    # not used at the moment
+    def init_weights(sequential, scales):
+        [
+            torch.nn.init.orthogonal_(module.weight, gain=scales[idx])
+            for idx, module in enumerate(mod for mod in sequential if isinstance(mod, nn.Linear))
+        ]
+
+    def reset(self, dones=None):
+        pass
+
+    def forward(self):
+        raise NotImplementedError
+
+    @property
+    def action_mean(self):
+        return self.distribution.mean
+
+    @property
+    def action_std(self):
+        return self.distribution.stddev
+
+    @property
+    def entropy(self):
+        return self.distribution.entropy().sum(dim=-1)
+
+    def update_distribution(self, observations):
+        # compute mean
+        mean = self.actor(observations)
+        # compute standard deviation
+        if self.noise_std_type == "scalar":
+            std = self.std.expand_as(mean)
+        elif self.noise_std_type == "log":
+            std = torch.exp(self.log_std).expand_as(mean)
+        else:
+            raise ValueError(f"Unknown standard deviation type: {self.noise_std_type}. Should be 'scalar' or 'log'")
+        # create distribution
+        self.distribution = Normal(mean, std)
+
+    def act(self, observations, **kwargs):
+        self.update_distribution(observations)
+        return self.distribution.sample()
+
+    def get_actions_log_prob(self, actions):
+        return self.distribution.log_prob(actions).sum(dim=-1)
+
+    def act_inference(self, observations):
+        actions_mean = self.actor(observations)
+        return actions_mean
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Load the parameters of the actor model.
+
+        Args:
+            state_dict (dict): State dictionary of the model.
+            strict (bool): Whether to strictly enforce that the keys in state_dict match the keys returned by this
+                           module's state_dict() function.
+
+        Returns:
+            bool: Whether this training resumes a previous training. This flag is used by the `load()` function of
+                  `OnPolicyRunner` to determine how to load further parameters (relevant for, e.g., distillation).
+        """
+
+        super().load_state_dict(state_dict, strict=strict)
+        return True


### PR DESCRIPTION
Adds a training script to train the linear estimator using supervised learning once a policy is already trained.

Also allows for optional use of the estimator during RL training (flag is set in go2_config), could be useful if we need a secondary RL stage after we get the linear estimator.

Other:
- removed noise from critic observations, should be ok since the critic is not used at run time, so no need to add noise to it.

Did not run it to check for runtime errors because no access to GPU.